### PR TITLE
Fixed JS error in admin widget when zero elements

### DIFF
--- a/sortedm2m/static/sortedm2m/widget.js
+++ b/sortedm2m/static/sortedm2m/widget.js
@@ -16,7 +16,7 @@ if (typeof jQuery === 'undefined') {
                 name = checkboxes.first().attr('name');
                 checkboxes.removeAttr('name');
             } else {
-                var label;
+                var label, labelFor;
                 var currentElement = ul;
 
                 while (!label || !label.length) {
@@ -24,7 +24,9 @@ if (typeof jQuery === 'undefined') {
                     label = currentElement.siblings('label');
                 }
 
-                id = label.attr('for').match(/^(.*)_\d+$/)[1];
+                labelFor = label.attr('for');
+                if (!labelFor) { return; }
+                id = labelFor.match(/^(.*)_\d+$/)[1];
                 name = id.replace(/^id_/, '');
             }
 


### PR DESCRIPTION
From @nemesisdesign via https://github.com/gregmuellegger/django-sortedm2m/pull/124

> This patch fixes an issue with the admin widget, which generates a javascript error when no m2m relations are present yet